### PR TITLE
Fix scss support and update to gulp-ruby-sass 1.0.0-alpha

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -26,7 +26,7 @@
     "gulp-replace": "^0.4.0",
     "gulp-rename": "^1.2.0",
     "gulp-rimraf": "^0.1.0"<% if (includeSass) { %>,
-    "gulp-ruby-sass": "^0.7.1"<% } if (includeLess) { %>,
+    "gulp-ruby-sass": "^1.0.0-alpha"<% } if (includeLess || includeSass) { %>,
     "gulp-sourcemaps": "^1.1.0"<% } if (includeTypeScript) { %>,
     "gulp-tslint": "^1.3.0"<% } %>,
     "gulp-uglify": "^0.3.0",

--- a/generators/app/templates/gulp/tasks/styles.js
+++ b/generators/app/templates/gulp/tasks/styles.js
@@ -5,9 +5,9 @@ var gulpif = require('gulp-if');
 var rename = require('gulp-rename');
 var csso = require('gulp-csso');
 var autoprefixer = require('gulp-autoprefixer');<% if (includeLess) { %>
-var less = require('gulp-less');
-var sourcemaps = require('gulp-sourcemaps');<% } else if (includeSass) { %>
-var sass = require('gulp-ruby-sass');<% } %>
+var less = require('gulp-less');<% } else if (includeSass) { %>
+var sass = require('gulp-ruby-sass');<% } %><% if (includeLess || includeSass ) { %>
+var sourcemaps = require('gulp-sourcemaps');<% } %>
 
 <% if (includeLess || includeSass) { %>
 function handleError(err) {
@@ -17,12 +17,11 @@ function handleError(err) {
 <% } %>
 
 module.exports = gulp.task('styles', function () {
-  return gulp.src(config.paths.src.styles)<% if (includeLess) { %>
-    .pipe(gulpif(!release, sourcemaps.init()))
-    .pipe(less().on('error', handleError))<% } else if (includeSass) { %>
-    .pipe(gulpif(release, sass().on('error', handleError), sass(/*{sourcemap: true, sourcemapPath: '../src/styles'}*/).on('error', handleError)))<% } %>
+  <% if (includeSass) { %>return sass(config.paths.src.styles, {sourcemap: !release } ).on('error', handleError)<% } else { %> return gulp.src(config.paths.src.styles) <% } %><% if (includeLess || includeSass) { %>
+    .pipe(gulpif(!release, sourcemaps.init())) <% } %><% if (includeLess) { %>
+    .pipe(less().on('error', handleError))<% } %>
     .pipe(autoprefixer('last 1 version'))
-    .pipe(gulpif(release, csso()))<% if (includeLess) { %>
+    .pipe(gulpif(release, csso()))<% if (includeLess || includeSass) { %>
     .pipe(gulpif(!release, sourcemaps.write()))<% } %>
     .pipe(gulpif(release, rename(config.filenames.release.styles), rename(config.filenames.build.styles)))
     .pipe(gulpif(release, gulp.dest(config.paths.dest.release.styles), gulp.dest(config.paths.dest.build.styles)));


### PR DESCRIPTION
I've tried using this generator and the scss didn't work for me, had to update to a newer gulp-ruby-sass version. It will now also generate sourcemaps in non-release builds.

Check the new docs here: https://github.com/sindresorhus/gulp-ruby-sass/tree/rw/1.0